### PR TITLE
🔧 配置GitHub Token用于自动发布

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,4 +39,4 @@ jobs:
 
       - run: gh release create v${{inputs.app-version}} dist/root* dist/latest*.yml --repo ${{github.repository}}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/electron-builder.mjs
+++ b/electron-builder.mjs
@@ -13,6 +13,18 @@ export default /** @type import('electron-builder').Configuration */
   linux: {
     target: ['deb'],
   },
+  mac: {
+    target: [
+      {
+        target: 'zip',
+        arch: ['arm64', 'x64']
+      }
+    ],
+    // 在CI环境中跳过DMG构建，避免hdiutil权限问题
+    ...(process.env.CI && {
+      target: [{ target: 'zip', arch: ['arm64', 'x64'] }]
+    })
+  },
   /**
    * It is recommended to avoid using non-standard characters such as spaces in artifact names,
    * as they can unpredictably change during deployment, making them impossible to locate and download for update.


### PR DESCRIPTION
修改内容：
- 移除compile阶段的空GH_TOKEN设置
- 在deploy工作流中使用secrets.GH_TOKEN

需要手动配置：
1. 创建GitHub Personal Access Token
   - 访问: https://github.com/settings/tokens
   - 权限: repo + write:packages
2. 在仓库中添加Secret
   - 名称: GH_TOKEN
   - 值: 刚创建的token

配置完成后，main分支合并时会自动创建GitHub Release！