### PR TITLE
🔧 恢复正确的自动发布机制

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,15 @@ jobs:
       app-version: ${{ needs.prepare.outputs.APP_FULL_VERSION }}
       distribution-channel: ${{inputs.distribution-channel}}
 
-# deploy job已移除，因为electron-builder在main分支会直接发布到GitHub
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    needs:
+      - prepare
+      - compile-and-test
+    uses: ./.github/workflows/deploy.yml
+    with:
+      distribution-channel: ${{ inputs.distribution-channel }}
+      app-version: ${{ needs.prepare.outputs.APP_FULL_VERSION }}
+    secrets: inherit

--- a/.github/workflows/compile-and-test.yml
+++ b/.github/workflows/compile-and-test.yml
@@ -49,15 +49,9 @@ jobs:
         name: Setup boilerplate
 
       - run: pnpm version "${{inputs.app-version}}" --no-git-tag-version
-      - run: |
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            pnpm run compile
-          else
-            pnpm run compile -- -p never
-          fi
+      - run: pnpm run compile -- -p never
         env:
           VITE_DISTRIBUTION_CHANNEL: ${{inputs.distribution-channel}}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - run: pnpm run test
         if: matrix.os != 'ubuntu-latest'


### PR DESCRIPTION
问题分析：
- 我错误地删除了deploy job
- 原来的机制是compile-and-test只构建，deploy job负责发布
- main分支构建成功但没有release是因为缺少deploy步骤

修复内容：
1. 恢复deploy job到ci.yml
2. compile-and-test始终使用 -p never (只构建不发布)
3. deploy job在main分支单独处理发布
4. 使用secrets.GH_TOKEN进行发布

正确的流程：
- PR阶段：compile-and-test构建，上传artifacts
- main分支：compile-and-test构建 → deploy job发布到GitHub Releases

这样避免了重复发布，保持了原有的清晰分工！