### PR TITLE
🔧 修复GitHub CLI token配置

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,4 +39,4 @@ jobs:
 
       - run: gh release create v${{inputs.app-version}} dist/root* dist/latest*.yml --repo ${{github.repository}}
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
错误信息：gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable

问题：GitHub CLI需要使用github.token而不是secrets.GH_TOKEN

修复：
- 在deploy.yml中使用 GH_TOKEN: ${{ github.token }}
- 保持secrets: inherit传递权限
- 确保deploy job有contents: write权限

GitHub CLI的标准配置就是使用github.token！